### PR TITLE
Add chunk expansion endpoints for speaker context retrieval

### DIFF
--- a/src/api/retrieval/routes.py
+++ b/src/api/retrieval/routes.py
@@ -2,7 +2,19 @@ from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query
 
-from src.api.schemas import BenchmarkResponse, ChunkResult, QueryRequest, QueryResponse
+from src.api.schemas import (
+    BenchmarkResponse,
+    ChunkResult,
+    ExpandRequest,
+    ExpandResponse,
+    QAPair,
+    QAPairsRequest,
+    QAPairsResponse,
+    QueryRequest,
+    QueryResponse,
+    TurnData,
+)
+from src.database.connection import execute_query
 from src.retrieval import (
     FullTextSearchRetriever,
     HybridRetriever,
@@ -219,3 +231,224 @@ async def benchmark_retrieval(
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Benchmark failed: {str(e)}")
+
+
+@router.post("/expand", response_model=ExpandResponse)
+async def expand_chunks(request: ExpandRequest):
+    """Expand chunk IDs to retrieve full speaker turn context
+
+    Given a list of chunk IDs (e.g., from retrieval results), this endpoint
+    fetches the complete speaker turn for each chunk. This is useful for:
+
+    - Getting full context around retrieved chunk snippets
+    - Preserving speaker attribution
+    - Understanding complete utterances that were split across chunks
+
+    **Deduplication:** If multiple chunks belong to the same turn, that turn
+    appears only once in the response.
+
+    **Returns:**
+    - List of turn data with speaker, full text, timestamps, section titles
+    - Total count of unique turns
+    - Query execution time
+    """
+    try:
+        timer = Timer()
+        timer.start()
+
+        # Query: Get distinct turns for the provided chunk IDs
+        query = """
+            SELECT DISTINCT
+                t.id AS turn_id,
+                t.doc_id,
+                t.ord,
+                t.speaker,
+                t.text AS full_text,
+                t.start_time_seconds,
+                t.section_title,
+                t.token_count
+            FROM turns t
+            INNER JOIN chunks c ON c.turn_id = t.id
+            WHERE c.id = ANY(%(chunk_ids)s)
+            ORDER BY t.doc_id, t.ord
+        """
+
+        results = execute_query(query, {"chunk_ids": request.chunk_ids})
+
+        query_time_ms = timer.stop()
+
+        # Convert to TurnData objects
+        turns = [
+            TurnData(
+                turn_id=row["turn_id"],
+                doc_id=row["doc_id"],
+                ord=row["ord"],
+                speaker=row["speaker"],
+                full_text=row["full_text"],
+                start_time_seconds=row["start_time_seconds"],
+                section_title=row["section_title"],
+                token_count=row["token_count"],
+            )
+            for row in results
+        ]
+
+        return ExpandResponse(
+            turns=turns,
+            total_turns=len(turns),
+            query_time_ms=round(query_time_ms, 2),
+        )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail="Expansion failed. Please verify the chunk IDs exist."
+        )
+
+
+@router.post("/qa-pairs", response_model=QAPairsResponse)
+async def generate_qa_pairs(request: QAPairsRequest):
+    """Generate Q&A pairs from turn IDs by pairing with previous turns
+
+    For each provided turn ID (the "answer"), this endpoint retrieves the
+    previous turn (the "question") from the same document. This creates
+    natural Q&A pairs for:
+
+    - Training question-answering models
+    - Building evaluation datasets
+    - Understanding conversational context
+
+    **Flexible Speaker Pairing:** Works with any speaker combination (not
+    limited to specific names like "Dwarkesh" or "Guest").
+
+    **Ordering:** Pairs are based on the `ord` field within each document.
+    The previous turn is the one with `ord = current_ord - 1`.
+
+    **Skipped Turns:** Turns without a valid previous turn (e.g., first turn
+    in a document) are skipped and counted in `skipped_turns`.
+
+    **Returns:**
+    - List of Q&A pairs (previous turn + target turn)
+    - Count of pairs generated
+    - Count of turns skipped (first-turn in doc, no previous)
+    - Count of turn IDs not found in database
+    - Query execution time
+    """
+    try:
+        timer = Timer()
+        timer.start()
+
+        # Deduplicate input turn IDs
+        unique_turn_ids = list(set(request.turn_ids))
+
+        # Query: Get turn pairs (current + previous) for provided turn IDs
+        # Also returns answer_turn_id for all found turns to calculate not_found
+        query = """
+            WITH target_turns AS (
+                SELECT
+                    t.id AS answer_turn_id,
+                    t.doc_id,
+                    t.ord AS answer_ord,
+                    t.speaker AS answer_speaker,
+                    t.text AS answer_text,
+                    t.start_time_seconds AS answer_start_time,
+                    t.section_title AS answer_section,
+                    t.token_count AS answer_tokens
+                FROM turns t
+                WHERE t.id = ANY(%(turn_ids)s)
+            ),
+            previous_turns AS (
+                SELECT
+                    t.id AS question_turn_id,
+                    t.doc_id,
+                    t.ord AS question_ord,
+                    t.speaker AS question_speaker,
+                    t.text AS question_text,
+                    t.start_time_seconds AS question_start_time,
+                    t.section_title AS question_section,
+                    t.token_count AS question_tokens
+                FROM turns t
+            )
+            SELECT
+                -- Question (previous turn)
+                pt.question_turn_id,
+                pt.doc_id AS question_doc_id,
+                pt.question_ord,
+                pt.question_speaker,
+                pt.question_text,
+                pt.question_start_time,
+                pt.question_section,
+                pt.question_tokens,
+                -- Answer (target turn)
+                tt.answer_turn_id,
+                tt.doc_id AS answer_doc_id,
+                tt.answer_ord,
+                tt.answer_speaker,
+                tt.answer_text,
+                tt.answer_start_time,
+                tt.answer_section,
+                tt.answer_tokens
+            FROM target_turns tt
+            INNER JOIN previous_turns pt
+                ON tt.doc_id = pt.doc_id
+                AND tt.answer_ord = pt.question_ord + 1
+            ORDER BY tt.doc_id, tt.answer_ord
+        """
+
+        results = execute_query(query, {"turn_ids": unique_turn_ids})
+
+        query_time_ms = timer.stop()
+
+        # Convert to QAPair objects
+        pairs = [
+            QAPair(
+                question_turn=TurnData(
+                    turn_id=row["question_turn_id"],
+                    doc_id=row["question_doc_id"],
+                    ord=row["question_ord"],
+                    speaker=row["question_speaker"],
+                    full_text=row["question_text"],
+                    start_time_seconds=row["question_start_time"],
+                    section_title=row["question_section"],
+                    token_count=row["question_tokens"],
+                ),
+                answer_turn=TurnData(
+                    turn_id=row["answer_turn_id"],
+                    doc_id=row["answer_doc_id"],
+                    ord=row["answer_ord"],
+                    speaker=row["answer_speaker"],
+                    full_text=row["answer_text"],
+                    start_time_seconds=row["answer_start_time"],
+                    section_title=row["answer_section"],
+                    token_count=row["answer_tokens"],
+                ),
+            )
+            for row in results
+        ]
+
+        # Count found turn IDs to distinguish not_found from skipped
+        found_turn_ids = {row["answer_turn_id"] for row in results}
+
+        # To properly count not_found, we need to check which turns exist
+        # The pairs only include turns with previous turns, so we need separate query
+        found_count_query = """
+            SELECT COUNT(*) as cnt FROM turns WHERE id = ANY(%(turn_ids)s)
+        """
+        count_result = execute_query(found_count_query, {"turn_ids": unique_turn_ids})
+        valid_turns_count = count_result[0]["cnt"] if count_result else 0
+
+        not_found_count = len(unique_turn_ids) - valid_turns_count
+        skipped_turns = valid_turns_count - len(pairs)  # Valid turns without previous turn
+
+        return QAPairsResponse(
+            pairs=pairs,
+            total_pairs=len(pairs),
+            skipped_turns=skipped_turns,
+            not_found_count=not_found_count,
+            query_time_ms=round(query_time_ms, 2),
+        )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail="Q&A pair generation failed. Please verify the turn IDs exist."
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def clean_db(db_connection):
     with db_connection.cursor() as cur:
         cur.execute("TRUNCATE chunk_embeddings CASCADE")
         cur.execute("TRUNCATE chunks CASCADE")
+        cur.execute("TRUNCATE turns CASCADE")
         cur.execute("TRUNCATE docs CASCADE")
         db_connection.commit()
 
@@ -48,6 +49,7 @@ def clean_db(db_connection):
     with db_connection.cursor() as cur:
         cur.execute("TRUNCATE chunk_embeddings CASCADE")
         cur.execute("TRUNCATE chunks CASCADE")
+        cur.execute("TRUNCATE turns CASCADE")
         cur.execute("TRUNCATE docs CASCADE")
         db_connection.commit()
 
@@ -78,3 +80,92 @@ def sample_text():
 def sample_short_text():
     """Provide short sample text for testing."""
     return "Machine learning is a cool technology that helps computers learn from data."
+
+
+@pytest.fixture
+def sample_podcast_with_turns(clean_db):
+    """Create a sample podcast document with turns and chunks for testing expansion endpoints.
+
+    Returns dict with doc_id, turn_ids, and chunk_ids for use in tests.
+    """
+    with clean_db.cursor() as cur:
+        # Create document
+        cur.execute(
+            """
+            INSERT INTO docs (source, url, title, doc_type, raw_text, metadata)
+            VALUES ('dwarkesh', 'https://example.com/podcast', 'Test Podcast Episode', 'transcript',
+                    'Full transcript text here', '{"guest": "Test Guest"}')
+            RETURNING id
+            """
+        )
+        doc_id = cur.fetchone()["id"]
+
+        # Create turns (simulating a podcast conversation)
+        turns_data = [
+            (0, "Dwarkesh Patel", 0, "What are your thoughts on AI safety?", "Introduction"),
+            (1, "Test Guest", 60, "AI safety is crucial for several reasons. First, we need to consider alignment.", "AI Safety"),
+            (2, "Dwarkesh Patel", 120, "Can you elaborate on alignment specifically?", "AI Safety"),
+            (3, "Test Guest", 180, "Alignment is about ensuring AI systems do what we intend. This involves technical research.", "AI Safety"),
+            (4, "Dwarkesh Patel", 240, "What about governance and policy?", "Governance"),
+            (5, "Test Guest", 300, "Governance frameworks are essential. We need international cooperation.", "Governance"),
+        ]
+
+        turn_ids = []
+        for ord_val, speaker, start_time, text, section in turns_data:
+            cur.execute(
+                """
+                INSERT INTO turns (doc_id, ord, speaker, start_time_seconds, text, section_title, token_count, metadata)
+                VALUES (%(doc_id)s, %(ord)s, %(speaker)s, %(start_time)s, %(text)s, %(section)s, %(tokens)s, '{}')
+                RETURNING id
+                """,
+                {
+                    "doc_id": doc_id,
+                    "ord": ord_val,
+                    "speaker": speaker,
+                    "start_time": start_time,
+                    "text": text,
+                    "section": section,
+                    "tokens": len(text.split()) * 2,  # Approximate token count
+                }
+            )
+            turn_ids.append(cur.fetchone()["id"])
+
+        # Create chunks linked to turns
+        # Turn 1 (guest's first answer) is long enough to have 2 chunks
+        chunks_data = [
+            (0, turn_ids[0], "What are your thoughts on AI safety?"),
+            (1, turn_ids[1], "AI safety is crucial for several reasons."),
+            (2, turn_ids[1], "First, we need to consider alignment."),  # Same turn, different chunk
+            (3, turn_ids[2], "Can you elaborate on alignment specifically?"),
+            (4, turn_ids[3], "Alignment is about ensuring AI systems do what we intend."),
+            (5, turn_ids[3], "This involves technical research."),  # Same turn
+            (6, turn_ids[4], "What about governance and policy?"),
+            (7, turn_ids[5], "Governance frameworks are essential. We need international cooperation."),
+        ]
+
+        chunk_ids = []
+        for ord_val, turn_id, text in chunks_data:
+            cur.execute(
+                """
+                INSERT INTO chunks (doc_id, turn_id, ord, text, token_count)
+                VALUES (%(doc_id)s, %(turn_id)s, %(ord)s, %(text)s, %(tokens)s)
+                RETURNING id
+                """,
+                {
+                    "doc_id": doc_id,
+                    "turn_id": turn_id,
+                    "ord": ord_val,
+                    "text": text,
+                    "tokens": len(text.split()) * 2,
+                }
+            )
+            chunk_ids.append(cur.fetchone()["id"])
+
+        clean_db.commit()
+
+        return {
+            "doc_id": doc_id,
+            "turn_ids": turn_ids,
+            "chunk_ids": chunk_ids,
+            "turns_data": turns_data,
+        }

--- a/tests/integration/test_chunk_expansion_integration.py
+++ b/tests/integration/test_chunk_expansion_integration.py
@@ -1,0 +1,448 @@
+"""Integration tests for chunk expansion endpoints."""
+
+import pytest
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@pytest.mark.integration
+class TestExpandChunksEndpoint:
+    """Test suite for POST /api/retrieval/expand endpoint."""
+
+    def test_expand_single_chunk(self, test_client, sample_podcast_with_turns):
+        """Test expanding a single chunk to its parent turn."""
+        # Arrange
+        chunk_ids = [sample_podcast_with_turns["chunk_ids"][0]]
+
+        # Act
+        response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_turns"] == 1
+        assert len(data["turns"]) == 1
+        assert data["query_time_ms"] >= 0
+
+        turn = data["turns"][0]
+        assert turn["turn_id"] == sample_podcast_with_turns["turn_ids"][0]
+        assert turn["speaker"] == "Dwarkesh Patel"
+        assert turn["full_text"] == "What are your thoughts on AI safety?"
+        assert turn["section_title"] == "Introduction"
+        assert turn["start_time_seconds"] == 0
+
+    def test_expand_multiple_chunks_different_turns(self, test_client, sample_podcast_with_turns):
+        """Test expanding multiple chunks from different turns."""
+        # Arrange - chunks 0 and 3 are from different turns
+        chunk_ids = [
+            sample_podcast_with_turns["chunk_ids"][0],
+            sample_podcast_with_turns["chunk_ids"][3],
+        ]
+
+        # Act
+        response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_turns"] == 2
+        assert len(data["turns"]) == 2
+
+        # Verify turns are ordered by doc_id, ord
+        speakers = [t["speaker"] for t in data["turns"]]
+        assert speakers == ["Dwarkesh Patel", "Dwarkesh Patel"]  # ord 0 and ord 2
+
+    def test_expand_deduplicates_same_turn(self, test_client, sample_podcast_with_turns):
+        """Test that multiple chunks from the same turn return only one turn."""
+        # Arrange - chunks 1 and 2 are both from turn_ids[1]
+        chunk_ids = [
+            sample_podcast_with_turns["chunk_ids"][1],
+            sample_podcast_with_turns["chunk_ids"][2],
+        ]
+
+        # Act
+        response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should be deduplicated to 1 turn
+        assert data["total_turns"] == 1
+        assert len(data["turns"]) == 1
+
+        turn = data["turns"][0]
+        assert turn["turn_id"] == sample_podcast_with_turns["turn_ids"][1]
+        assert turn["speaker"] == "Test Guest"
+        assert "AI safety is crucial" in turn["full_text"]
+
+    def test_expand_nonexistent_chunk_ids(self, test_client, sample_podcast_with_turns):
+        """Test expanding with non-existent chunk IDs returns empty result."""
+        # Arrange
+        chunk_ids = [999999, 888888]
+
+        # Act
+        response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_turns"] == 0
+        assert len(data["turns"]) == 0
+
+    def test_expand_mixed_valid_invalid_chunk_ids(self, test_client, sample_podcast_with_turns):
+        """Test expanding with mix of valid and invalid chunk IDs."""
+        # Arrange
+        chunk_ids = [
+            sample_podcast_with_turns["chunk_ids"][0],
+            999999,  # Invalid
+        ]
+
+        # Act
+        response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should return only the valid turn
+        assert data["total_turns"] == 1
+        assert len(data["turns"]) == 1
+
+    def test_expand_empty_chunk_ids_rejected(self, test_client, sample_podcast_with_turns):
+        """Test that empty chunk_ids list is rejected by validation."""
+        # Arrange
+        chunk_ids: list[int] = []
+
+        # Act
+        response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+
+        # Assert
+        assert response.status_code == 422  # Pydantic validation error
+
+    def test_expand_returns_correct_turn_fields(self, test_client, sample_podcast_with_turns):
+        """Test that all turn fields are returned correctly."""
+        # Arrange
+        chunk_ids = [sample_podcast_with_turns["chunk_ids"][1]]
+
+        # Act
+        response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        turn = data["turns"][0]
+        assert "turn_id" in turn
+        assert "doc_id" in turn
+        assert "ord" in turn
+        assert "speaker" in turn
+        assert "full_text" in turn
+        assert "start_time_seconds" in turn
+        assert "section_title" in turn
+        assert "token_count" in turn
+
+        # Verify specific values
+        assert turn["doc_id"] == sample_podcast_with_turns["doc_id"]
+        assert turn["ord"] == 1
+        assert turn["start_time_seconds"] == 60
+        assert turn["section_title"] == "AI Safety"
+
+    def test_expand_all_chunks(self, test_client, sample_podcast_with_turns):
+        """Test expanding all chunks returns all unique turns."""
+        # Arrange
+        chunk_ids = sample_podcast_with_turns["chunk_ids"]
+
+        # Act
+        response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        # We have 8 chunks mapping to 6 turns
+        assert data["total_turns"] == 6
+        assert len(data["turns"]) == 6
+
+        # Verify ordering by ord
+        ords = [t["ord"] for t in data["turns"]]
+        assert ords == [0, 1, 2, 3, 4, 5]
+
+
+@pytest.mark.integration
+class TestQAPairsEndpoint:
+    """Test suite for POST /api/retrieval/qa-pairs endpoint."""
+
+    def test_qa_pairs_single_turn(self, test_client, sample_podcast_with_turns):
+        """Test generating Q&A pair for a single turn."""
+        # Arrange - turn_ids[1] (Guest's answer) should pair with turn_ids[0] (Dwarkesh's question)
+        turn_ids = [sample_podcast_with_turns["turn_ids"][1]]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_pairs"] == 1
+        assert data["skipped_turns"] == 0
+        assert data["not_found_count"] == 0
+        assert data["query_time_ms"] >= 0
+
+        pair = data["pairs"][0]
+        assert pair["question_turn"]["speaker"] == "Dwarkesh Patel"
+        assert pair["question_turn"]["full_text"] == "What are your thoughts on AI safety?"
+        assert pair["answer_turn"]["speaker"] == "Test Guest"
+        assert "AI safety is crucial" in pair["answer_turn"]["full_text"]
+
+    def test_qa_pairs_multiple_turns(self, test_client, sample_podcast_with_turns):
+        """Test generating Q&A pairs for multiple turns."""
+        # Arrange - turns 1, 3, 5 (guest answers)
+        turn_ids = [
+            sample_podcast_with_turns["turn_ids"][1],
+            sample_podcast_with_turns["turn_ids"][3],
+            sample_podcast_with_turns["turn_ids"][5],
+        ]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_pairs"] == 3
+        assert data["skipped_turns"] == 0
+        assert data["not_found_count"] == 0
+
+        # All pairs should have Dwarkesh asking, Guest answering
+        for pair in data["pairs"]:
+            assert pair["question_turn"]["speaker"] == "Dwarkesh Patel"
+            assert pair["answer_turn"]["speaker"] == "Test Guest"
+
+    def test_qa_pairs_first_turn_skipped(self, test_client, sample_podcast_with_turns):
+        """Test that first turn in document is skipped (no previous turn)."""
+        # Arrange - turn_ids[0] is the first turn (ord=0)
+        turn_ids = [sample_podcast_with_turns["turn_ids"][0]]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_pairs"] == 0
+        assert data["skipped_turns"] == 1  # First turn has no previous
+        assert data["not_found_count"] == 0
+
+    def test_qa_pairs_mixed_valid_first_turns(self, test_client, sample_podcast_with_turns):
+        """Test mix of first turn (skipped) and valid turns."""
+        # Arrange
+        turn_ids = [
+            sample_podcast_with_turns["turn_ids"][0],  # First turn - will be skipped
+            sample_podcast_with_turns["turn_ids"][1],  # Valid - has previous
+        ]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_pairs"] == 1
+        assert data["skipped_turns"] == 1
+        assert data["not_found_count"] == 0
+
+    def test_qa_pairs_nonexistent_turn_ids(self, test_client, sample_podcast_with_turns):
+        """Test Q&A pairs with non-existent turn IDs."""
+        # Arrange
+        turn_ids = [999999, 888888]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_pairs"] == 0
+        assert data["skipped_turns"] == 0
+        assert data["not_found_count"] == 2  # Both IDs not found
+
+    def test_qa_pairs_mixed_valid_invalid_turn_ids(self, test_client, sample_podcast_with_turns):
+        """Test Q&A pairs with mix of valid and invalid turn IDs."""
+        # Arrange
+        turn_ids = [
+            sample_podcast_with_turns["turn_ids"][1],  # Valid
+            999999,  # Invalid
+        ]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_pairs"] == 1
+        assert data["skipped_turns"] == 0
+        assert data["not_found_count"] == 1
+
+    def test_qa_pairs_duplicate_turn_ids_deduplicated(self, test_client, sample_podcast_with_turns):
+        """Test that duplicate turn IDs are deduplicated."""
+        # Arrange - same turn ID three times
+        turn_ids = [
+            sample_podcast_with_turns["turn_ids"][1],
+            sample_podcast_with_turns["turn_ids"][1],
+            sample_podcast_with_turns["turn_ids"][1],
+        ]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should only return 1 pair (deduplicated)
+        assert data["total_pairs"] == 1
+        assert data["skipped_turns"] == 0
+        assert data["not_found_count"] == 0
+
+    def test_qa_pairs_empty_turn_ids_rejected(self, test_client, sample_podcast_with_turns):
+        """Test that empty turn_ids list is rejected by validation."""
+        # Arrange
+        turn_ids: list[int] = []
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 422  # Pydantic validation error
+
+    def test_qa_pairs_returns_correct_fields(self, test_client, sample_podcast_with_turns):
+        """Test that all Q&A pair fields are returned correctly."""
+        # Arrange
+        turn_ids = [sample_podcast_with_turns["turn_ids"][1]]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        pair = data["pairs"][0]
+
+        # Check question_turn fields
+        q = pair["question_turn"]
+        assert "turn_id" in q
+        assert "doc_id" in q
+        assert "ord" in q
+        assert "speaker" in q
+        assert "full_text" in q
+        assert "start_time_seconds" in q
+        assert "section_title" in q
+        assert "token_count" in q
+
+        # Check answer_turn fields
+        a = pair["answer_turn"]
+        assert "turn_id" in a
+        assert "doc_id" in a
+        assert "ord" in a
+        assert "speaker" in a
+        assert "full_text" in a
+        assert "start_time_seconds" in a
+        assert "section_title" in a
+        assert "token_count" in a
+
+        # Verify ordering (question should have ord one less than answer)
+        assert q["ord"] == a["ord"] - 1
+
+    def test_qa_pairs_flexible_speaker_pairing(self, test_client, sample_podcast_with_turns):
+        """Test that Q&A pairs work with any speaker combination."""
+        # Arrange - turn_ids[2] is Dwarkesh's follow-up, paired with turn_ids[1] (Guest)
+        turn_ids = [sample_podcast_with_turns["turn_ids"][2]]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_pairs"] == 1
+        pair = data["pairs"][0]
+
+        # Guest is the "question" (previous turn), Dwarkesh is the "answer" (target turn)
+        assert pair["question_turn"]["speaker"] == "Test Guest"
+        assert pair["answer_turn"]["speaker"] == "Dwarkesh Patel"
+
+    def test_qa_pairs_all_guest_turns(self, test_client, sample_podcast_with_turns):
+        """Test Q&A pairs for all guest turns (typical use case)."""
+        # Arrange - all guest turns (1, 3, 5)
+        turn_ids = [
+            sample_podcast_with_turns["turn_ids"][1],
+            sample_podcast_with_turns["turn_ids"][3],
+            sample_podcast_with_turns["turn_ids"][5],
+        ]
+
+        # Act
+        response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_pairs"] == 3
+
+        # Each pair should have Dwarkesh's question followed by Guest's answer
+        for pair in data["pairs"]:
+            assert pair["question_turn"]["speaker"] == "Dwarkesh Patel"
+            assert pair["answer_turn"]["speaker"] == "Test Guest"
+
+
+@pytest.mark.integration
+class TestExpandAndQAPairsIntegration:
+    """Test integration between expand and qa-pairs endpoints."""
+
+    def test_expand_then_qa_pairs_workflow(self, test_client, sample_podcast_with_turns):
+        """Test typical workflow: retrieve chunks, expand to turns, then get Q&A pairs."""
+        # Step 1: Expand chunks to turns
+        chunk_ids = [
+            sample_podcast_with_turns["chunk_ids"][1],  # Guest's first chunk
+            sample_podcast_with_turns["chunk_ids"][4],  # Guest's second answer chunk
+        ]
+
+        expand_response = test_client.post("/api/retrieval/expand", json={"chunk_ids": chunk_ids})
+        assert expand_response.status_code == 200
+        expand_data = expand_response.json()
+
+        # Should get 2 unique turns
+        assert expand_data["total_turns"] == 2
+
+        # Step 2: Get Q&A pairs for those turns
+        turn_ids = [t["turn_id"] for t in expand_data["turns"]]
+
+        qa_response = test_client.post("/api/retrieval/qa-pairs", json={"turn_ids": turn_ids})
+        assert qa_response.status_code == 200
+        qa_data = qa_response.json()
+
+        # Both turns have previous turns, so both should produce pairs
+        assert qa_data["total_pairs"] == 2
+        assert qa_data["skipped_turns"] == 0
+
+        # Verify the Q&A context makes sense
+        for pair in qa_data["pairs"]:
+            # The question should be Dwarkesh's prompt
+            assert pair["question_turn"]["speaker"] == "Dwarkesh Patel"
+            # The answer should be the Guest's response
+            assert pair["answer_turn"]["speaker"] == "Test Guest"


### PR DESCRIPTION
## Summary

Implements issue #31 - adds two new retrieval endpoints for expanding chunks to their full speaker turn context:

- **POST /api/retrieval/expand**: Expand chunk IDs to full speaker turns (deduplicated)
- **POST /api/retrieval/qa-pairs**: Generate Q&A pairs from turn IDs by pairing with previous turns

## Key Features

- Deduplication of turns when multiple chunks reference the same turn
- Flexible speaker pairing (works with any speaker combination, not Dwarkesh-specific)
- Proper tracking of `skipped_turns` vs `not_found_count` for debugging
- Query timing instrumentation (`query_time_ms`) for performance monitoring
- Sanitized error messages

## Files Changed

| File | Changes |
|------|---------|
| `src/api/schemas.py` | Added 6 new Pydantic schemas for request/response |
| `src/api/retrieval/routes.py` | Added 2 new endpoints with SQL queries |
| `tests/conftest.py` | Added `sample_podcast_with_turns` fixture |
| `tests/integration/test_chunk_expansion_integration.py` | 20 integration tests |

## Test plan

- [x] All 20 integration tests pass
- [x] `pyrefly check` passes with 0 errors on modified files
- [ ] Manual testing via `/docs` UI with real podcast data

## Closes

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)